### PR TITLE
Set up proper logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ autoscaling.config.json*
 autoscaling.clusters.json*
 nosetests.xml
 /.coverage
+*.log

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,6 @@ lint:
 	pylint --rcfile=.pylintrc src/
 
 server:
-	eval `ssh-agent -s` && PYTHONPATH=$(dir)/src src/themis/main.py server_and_loop -p 8081
+	eval `ssh-agent -s` && PYTHONPATH=$(dir)/src src/themis/main.py server_and_loop --port=8081 --log=themis.log
 
 .PHONY: build test

--- a/bin/autoscaler.service
+++ b/bin/autoscaler.service
@@ -14,7 +14,7 @@ running=`ps aux | grep server_and_loop | grep -v grep | awk '{print $2}'`
 echo "Running: $running"
 start() {
 	echo "Starting autoscaler in screen session"
-        (cd $loc/src/themis && sudo -u $user screen -S autoscaler -d -m bash -c "PYTHONPATH=$loc/src ./main.py server_and_loop -p $port")
+        (cd $loc/src/themis && sudo -u $user screen -S autoscaler -d -m bash -c "PYTHONPATH=$loc/src ./main.py server_and_loop --port=$port --log=themis.log")
 }
 stop() {
         ps aux | grep server_and_loop | grep -v grep | awk '{print $2}' | xargs kill

--- a/src/themis/config.py
+++ b/src/themis/config.py
@@ -1,7 +1,7 @@
 import os
 import json
 from themis.util import common
-from themis.util.common import run,log
+from themis.util.common import run
 from themis.constants import *
 
 # config file location
@@ -29,9 +29,12 @@ CLUSTER_LIST = common.load_json_file(CLUSTERS_FILE_LOCATION, [])
 # set this to override config for testing
 TEST_CONFIG = None
 
+# logger
+LOG = common.get_logger(__name__)
+
 def init_clusters_file():
 	if not os.path.isfile(CLUSTERS_FILE_LOCATION):
-		log("Initializing config file with list of clusters from AWS: %s" % CLUSTERS_FILE_LOCATION)
+		LOG.info("Initializing config file with list of clusters from AWS: %s" % CLUSTERS_FILE_LOCATION)
 		cfg = []
 
 		out = run('aws emr list-clusters')
@@ -56,7 +59,7 @@ def init_clusters_file():
 					if app['Name'] == 'Ganglia':
 						has_ganglia = True
 				if has_ganglia:
-					log('Getting details for cluster %s' % c['Id'])
+					LOG.info('Getting details for cluster %s' % c['Id'])
 					# get private IP address of cluster
 					for g in cluster_details['InstanceGroups']:
 						if g['InstanceGroupType'] == 'MASTER':
@@ -67,9 +70,9 @@ def init_clusters_file():
 									cluster['ip'] = inst['PrivateDnsName']
 					cfg.append(cluster)
 				else:
-					log('Ignoring cluster %s (Ganglia not installed)' % c['Id'])
+					LOG.info('Ignoring cluster %s (Ganglia not installed)' % c['Id'])
 		common.save_json_file(CLUSTERS_FILE_LOCATION, cfg)
-		log('Done.')
+		LOG.info('Done initializing.')
 
 def read():
 	appConfig = common.load_json_file(CONFIG_FILE_LOCATION)

--- a/src/themis/main.py
+++ b/src/themis/main.py
@@ -5,52 +5,56 @@ Main script for cluster auto-scaling based on monitoring data.
 
 Usage:
   main.py build
-  main.py server [ (-p | --port) <port> ]
-  main.py loop
-  main.py server_and_loop [ (-p | --port) <port> ]
+  main.py server [ --port=<port> ] [ --log=<log_file> ]
+  main.py loop [ --log=<log_file> ]
+  main.py server_and_loop [ --port=<port> ] [ --log=<log_file> ]
   main.py (-h | --help)
 
 Options:
-  -h --help     Show this screen.
-
+  -h --help     		Show this screen.
+  --port=<port>  		Port the server should listen on.
+  --log=<log_file>     	Log file path.
 """
 
 import subprocess
 from docopt import docopt
 import math
+import logging
 from themis import config
-from themis.util import math_util
-from themis.util import aws_pricing
 from themis.util.common import *
 
 DEFAULT_PORT = 8000
 
-
 if __name__ == "__main__":
 	args = docopt(__doc__)
+	port = args['--port'] or DEFAULT_PORT
+	log_file = args['--log'] or ''
+
+	# set up logging
+	setup_logging(log_file)
+
 	if args['server_and_loop']:
 		config.init_clusters_file()
 		def run(cmd):
 			subprocess.call(cmd, shell=True)
-		port = args['<port>'] or DEFAULT_PORT
-		cmd = os.path.realpath(__file__) + " loop"
+		cmd = os.path.realpath(__file__) + " loop --log=%s" % (log_file)
 		t1 = threading.Thread(target = run, args = (cmd,))
 		t1.start()
-		cmd = os.path.realpath(__file__) + " server -p %s" % port
+		cmd = os.path.realpath(__file__) + " server --port=%s --log=%s" % (port, log_file)
 		t2 = threading.Thread(target = run, args = (cmd,))
 		t2.start()
 		try:
 			t2.join()
 		except KeyboardInterrupt, e:
 			pass
-	if args['server']:
-		from scaling import server
-		port = args['<port>'] or DEFAULT_PORT
-		server.serve(port)
-	if args['loop']:
-		from scaling import server
-		try:
-			server.loop()
-		except KeyboardInterrupt, e:
-			pass
+	else:
+		if args['server']:
+			from scaling import server
+			server.serve(port)
+		if args['loop']:
+			from scaling import server
+			try:
+				server.loop()
+			except KeyboardInterrupt, e:
+				pass
 

--- a/src/themis/util/aws_pricing.py
+++ b/src/themis/util/aws_pricing.py
@@ -12,6 +12,8 @@ LOCATION_NAMES = {
 	'us-east-1': 'US East (N. Virginia)'
 }
 
+LOG = get_logger(__name__)
+
 def get_short_zone(zone):
 	zone = re.sub(r'-([1-9])[a-z]$', r'-\1', zone)
 	return zone
@@ -32,7 +34,7 @@ def get_spot_history(zone, type):
 		result = json.loads(result)
 	else:
 		cmd = "aws ec2 describe-spot-price-history --start-time %s --end-time %s --availability-zone %s --instance-types %s --max-items 15000" % (start_time, end_time, zone, type)
-		log('Loading AWS spot prices for zone "%s" and type "%s"' % (zone, type))
+		LOG.info('Loading AWS spot prices for zone "%s" and type "%s"' % (zone, type))
 		result = run(cmd)
 		open(file, 'w+').write(result)
 		result = json.loads(result)
@@ -48,7 +50,7 @@ def load_fixed_prices(zone):
 		result = open(file).read()
 		result = json.loads(result)
 	else:
-		log("Downloading latest pricing information from AWS")
+		LOG.info("Downloading latest pricing information from AWS")
 		cmd = "curl %s > %s" % (url, file)
 		run(cmd)
 		result = open(file).read()
@@ -74,7 +76,7 @@ def get_fixed_price(zone, type, os='Linux', tenancy='Shared'):
 							raise Exception("Multiple price dimensions found for %s" % key)
 						price = float(price_dim.values()[0]['pricePerUnit']['USD'])
 						if result:
-							log('WARNING: multiple prices detected %s %s' % (price, attrs['operatingSystem']))
+							LOG.info('WARNING: multiple prices detected %s %s' % (price, attrs['operatingSystem']))
 						else:
 							result = price
 	return result
@@ -178,7 +180,7 @@ def get_cluster_savings(info, baseline_nodes, zone='us-east-1'):
 				if not baseline_instance_type:
 					baseline_instance_type = instance_types[node]
 				if baseline_instance_type != instance_types[node]:
-					print("WARN: Found different node instance types. Using type '%s' as baseline" % baseline_instance_type)
+					LOG.warn("Found different node instance types. Using type '%s' as baseline" % baseline_instance_type)
 				if node not in instance_end_times or instance_end_times[node] < timestamp:
 					instance_end_times[node] = timestamp
 				if node not in instance_start_times or instance_start_times[node] > timestamp:

--- a/src/themis/util/monitoring.py
+++ b/src/themis/util/monitoring.py
@@ -13,6 +13,8 @@ from themis.util import aws_common, common, expr
 from themis.util.common import *
 from themis.util.remote import run_ssh
 
+# logger
+LOG = get_logger(__name__)
 
 # global DB connection
 db_connection = None
@@ -126,7 +128,7 @@ def get_cluster_load(cluster_info, task_nodes=None, monitoring_interval_secs=MON
 				load = get_node_load(cluster_ip, cluster_id, host, monitoring_interval_secs)
 				result[host] = load
 			except Exception, e:
-				log("WARN: Unable to get load for node %s: %s" % (host, e))
+				LOG.warning("Unable to get load for node %s: %s" % (host, e))
 				result[host] = {}
 
 	parallelize(nodes, query)
@@ -358,7 +360,8 @@ def get_minimum_nodes(date):
 			if nodes_to_return is None:
 				nodes_to_return = num_nodes
 			else:
-				print "WARNING! '%s' Regex Pattern has matched more then once:\nnodes_to_return=%d is now changing to nodes_to_return=%d" % (pattern,nodes_to_return,num_nodes)
+				LOG.warning("'%s' Regex Pattern has matched more than once:\nnodes_to_return=%d is now changing to nodes_to_return=%d" %
+					(pattern,nodes_to_return,num_nodes))
 				nodes_to_return = num_nodes
 	## no match revert to default
 	if nodes_to_return is None:

--- a/test/mock/ganglia.py
+++ b/test/mock/ganglia.py
@@ -64,5 +64,4 @@ def mock_ganglia(cpu=None, mem=None):
 			mem_free_dp.append([mem_free,t])
 		t += 15
 
-	print(result)
 	return make_response(json.dumps(result))

--- a/test/test_fetch_cluster_info.py
+++ b/test/test_fetch_cluster_info.py
@@ -20,18 +20,16 @@ def test_list_instances():
 	server.config['group_id_task_spot'] = common.short_uid()
 	server.config['group_id_task_od'] = common.short_uid()
 
-	out = common.run("aws emr list-instances --cluster-id=testClusterID1", print_error=True)
-	#print out
+	out = common.run("aws emr list-instances --cluster-id=testClusterID1", log_error=True)
 	out = json.loads(out)
 	assert len(out['Instances']) > 0
 
 	nodes = aws_common.get_cluster_nodes('testClusterID1')
-	#print nodes
 	assert len(nodes) > 1
 
 def test_aws_cli():
 	init_mocks()
 
-	out = common.run("aws emr list-clusters", print_error=True)
+	out = common.run("aws emr list-clusters", log_error=True)
 	out = json.loads(out)
 	assert out['Clusters'][0]['Id'] == 'testClusterID1'

--- a/test/test_scaling_decisions.py
+++ b/test/test_scaling_decisions.py
@@ -26,7 +26,6 @@ def mock_cluster_state(nodes=0, config=None):
 		'type': aws_common.CLUSTER_TYPE_PRESTO
 	}
 	info = monitoring.collect_info(cluster_info, config=config, task_nodes=task_nodes)
-	print(info)
 	return info
 
 def get_server():


### PR DESCRIPTION
This PR removes all `print` statements and sets up proper logging. A CLI flag `--log=..` has been added to specify the log file path.