### PR TITLE
Support temporary STS tokens via assumed IAM roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ nosetests.xml
 /.coverage
 *.log
 .venv/
+*.sd.yml
 *.egg-info/
 /dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2-onbuild
+FROM python:2
 
 MAINTAINER Waldemar Hummer (whummer@atlassian.com)
 
@@ -12,12 +12,21 @@ RUN apt-get update && apt-get install -y gcc git make npm && apt-get clean
 # install Themis package
 RUN pip install themis-autoscaler
 
+# Copy themis files from local copy
+ADD bin /opt/code/themis/bin
+ADD themis /opt/code/themis/themis
+RUN rm -f /usr/local/bin/themis && ln -s /opt/code/themis/bin/themis /usr/local/bin/themis
+
+# Set PYTHONPATH
+ENV PYTHONPATH /opt/code/themis
+
 # make sure we have write access to workdir
-RUN chmod 777 -R /opt/code/themis/
+RUN chmod 777 /opt/code/themis/
 
 # assign random user id
-USER 24624336
-ENV USER docker
+# TODO: we currently can't use "random" uid because then ssh commands fail
+# USER 24624336
+# ENV USER docker
 
 # expose service port
 EXPOSE 8080
@@ -26,4 +35,4 @@ EXPOSE 8080
 ENV AWS_DEFAULT_REGION us-east-1
 
 # define command
-CMD ["themis", "server_and_loop", "--port=8080", "--log=themis.log"]
+ENTRYPOINT ["themis"]

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ docker-build:      ## Build the Docker image
 docker-push:       ## Push image to Docker hub
 	docker push $(IMAGE_NAME)
 
+docker-run:        ## Run Themis in local Docker container
+	docker run -it -p 8080:8080 -e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) -e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) -e AWS_SESSION_TOKEN=$(AWS_SESSION_TOKEN) -e SSH_KEY_ETL_PROD="$(SSH_KEY_ETL_PROD)" $(IMAGE_NAME) server_and_loop --port=8080
+
 test:              ## Run tests
 	($(VENV_RUN) && PYTHONPATH=$(dir)/test:$$PYTHONPATH nosetests --nocapture --no-skip --with-coverage --with-xunit --cover-package=themis test/) && \
 	make lint

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ make server
 
 ## Change Log
 
+* v0.2.4: Support temporary STS tokens via assumed IAM roles
+* v0.2.3: Use boto3 for AWS API calls
 * v0.2.1: Add Dockerfile, publish image to Docker hub
 * v0.2.0: Kinesis autoscaling; some fixes in UI; extend tests; update documentation
 * v0.1.15: Initial version of auto-scaling Kinesis streams; first release tag

--- a/bin/themis
+++ b/bin/themis
@@ -41,7 +41,6 @@ if __name__ == "__main__":
     setup_logging(log_file)
 
     if args['server_and_loop']:
-        # resources.init_resources_file()
 
         def run(cmd):
             process = subprocess.Popen(cmd, shell=True, stdout=sys.stdout, stderr=sys.stderr)

--- a/bin/themis
+++ b/bin/themis
@@ -41,14 +41,19 @@ if __name__ == "__main__":
     setup_logging(log_file)
 
     if args['server_and_loop']:
-        resources.init_resources_file()
+        # resources.init_resources_file()
 
         def run(cmd):
-            subprocess.call(cmd, shell=True)
+            process = subprocess.Popen(cmd, shell=True, stdout=sys.stdout, stderr=sys.stderr)
+            process.communicate()
+
+        cmd_prefix = 'eval `ssh-agent -s`; '
         cmd = os.path.realpath(__file__) + " loop --log=%s" % (log_file)
+        cmd = cmd_prefix + cmd
         t1 = threading.Thread(target=run, args=(cmd, ))
         t1.start()
         cmd = os.path.realpath(__file__) + " server --port=%s --log=%s" % (port, log_file)
+        cmd = cmd_prefix + cmd
         t2 = threading.Thread(target=run, args=(cmd, ))
         t2.start()
         try:

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
 
     setup(
         name='themis-autoscaler',
-        version='0.2.3',
+        version='0.2.4',
         description='Themis is an autoscaler for Elastic Map Reduce (EMR) clusters on Amazon Web Services.',
         author='Atlassian and others',
         maintainer='Waldemar Hummer',

--- a/test/constants.py
+++ b/test/constants.py
@@ -5,6 +5,12 @@ AWS_API_PORT = 9896
 GANGLIA_PORT = 9897
 LOCALHOST = '127.0.0.1'
 BIND_HOST = '0.0.0.0'
+DEFAULT_REGION = 'us-east-1'
+
+# set test values for boto3 credentials
+os.environ['AWS_DEFAULT_REGION'] = DEFAULT_REGION
+os.environ['AWS_ACCESS_KEY_ID'] = 'test_access_key'
+os.environ['AWS_SECRET_ACCESS_KEY'] = 'test_secret_key'
 
 try:
     tmp = os.environ.AWS_ENDPOINT_URL

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,0 +1,42 @@
+import requests
+import json
+import threading
+import time
+from constants import *
+from themis.constants import *
+from themis.util.common import FuncThread
+from themis import api
+
+
+TEST_API_PORT = 9876
+TEST_API_ENDPOINT = 'http://localhost:%s' % TEST_API_PORT
+
+
+def setup():
+    thread = FuncThread(api.serve, TEST_API_PORT)
+    thread.start()
+    time.sleep(2)
+
+
+def test_api_calls():
+    response = requests.get('%s/healthcheck' % TEST_API_ENDPOINT)
+    assert(response.status_code == 200)
+    body = json.loads(response.text)
+    assert(body['status'] == 'OK')
+
+    response = requests.get('%s/swagger.json' % TEST_API_ENDPOINT)
+    assert('Themis' in response.text)
+
+    response = requests.get('%s/config/general' % TEST_API_ENDPOINT)
+    configs = response.text
+    assert('config' in json.loads(configs))
+
+    response = requests.post('%s/config/general/' % TEST_API_ENDPOINT, data=configs)
+    assert('config' in json.loads(response.text))
+
+    request = '{"cluster_id": "test", "node_host": "test"}'
+    response = requests.post('%s/emr/restart' % TEST_API_ENDPOINT, data=request)
+    assert('Invalid cluster ID' in response.text)
+
+    response = requests.get('%s/kinesis/streams' % TEST_API_ENDPOINT)
+    assert('results' in json.loads(response.text))

--- a/themis/api.py
+++ b/themis/api.py
@@ -183,7 +183,7 @@ def restart_emr_node():
     cluster_id = data['cluster_id']
     node_host = data['node_host']
     app_config = config.get_config()
-    clusters = app_config.emr
+    clusters = app_config.emr.to_dict()
     for c_id, details in clusters.iteritems():
         if c_id == cluster_id:
             cluster_ip = details.ip
@@ -277,4 +277,4 @@ def send_static(path):
 
 
 def serve(port):
-    app.run(port=int(port), debug=True, threaded=True, host='0.0.0.0')
+    app.run(port=int(port), debug=False, threaded=True, host='0.0.0.0')

--- a/themis/api.py
+++ b/themis/api.py
@@ -35,6 +35,14 @@ def spec():
     return jsonify(swag)
 
 
+@app.route('/healthcheck')
+def healthcheck():
+    result = {
+        'status': 'OK'
+    }
+    return jsonify(result)
+
+
 @app.route('/config/<section>', methods=['GET'])
 def get_global_config(section):
     """ Get global configuration

--- a/themis/monitoring/database.py
+++ b/themis/monitoring/database.py
@@ -9,7 +9,6 @@ DB_FILE_NAME = 'monitoring.data.db'
 DB_TABLE_HISTORY = 'states_history'
 
 
-# TODO needed?
 class HistoricalState(object):
     def __init__(self, section, resource, state=None, action=None):
         self.timestamp = time.time() * 1000.0
@@ -45,6 +44,8 @@ def history_add(section, resource, state, action):
     c.execute(("INSERT INTO %s(timestamp,section,resource,state,action) " +
         "VALUES (?,?,?,?,?)") % DB_TABLE_HISTORY, (ms, section, resource, state, action))
     conn.commit()
+    state = HistoricalState(section, resource, state=state, action=action)
+    return state
 
 
 def history_get(section, resource, limit=100):

--- a/themis/monitoring/resources.py
+++ b/themis/monitoring/resources.py
@@ -6,7 +6,7 @@ from themis.util.common import *
 from themis.model.aws_model import *
 from themis.model.emr_model import *
 from themis.model.kinesis_model import *
-from themis.model.resources_model import *
+import themis.model.resources_model
 import themis.monitoring.kinesis_monitoring
 import themis.monitoring.emr_monitoring
 
@@ -55,7 +55,7 @@ def get_resource(section, resource_id):
 
 def load_resources_config():
     content = load_json_file(RESOURCES_FILE_LOCATION)
-    cfg = ResourcesConfiguration.from_dict(content)
+    cfg = themis.model.resources_model.ResourcesConfiguration.from_dict(content)
     return cfg
 
 
@@ -79,7 +79,7 @@ def init_resources_file(run_parallel=False):
     sys_config = get_config()
     roles = re.split(r'\s*,\s*', sys_config.general.roles_to_assume)
 
-    cfg = ResourcesConfiguration()
+    cfg = themis.model.resources_model.ResourcesConfiguration()
     LOG.info("Initializing config file with list of resources from AWS: %s" % RESOURCES_FILE_LOCATION)
 
     for role in roles:

--- a/themis/monitoring/resources.py
+++ b/themis/monitoring/resources.py
@@ -1,4 +1,7 @@
+import re
+from themis import config
 from themis.config import *
+from themis.util import aws_common
 from themis.util.common import *
 from themis.model.aws_model import *
 from themis.model.emr_model import *
@@ -7,28 +10,39 @@ from themis.model.resources_model import *
 import themis.monitoring.kinesis_monitoring
 import themis.monitoring.emr_monitoring
 
-# global pointer for list of resources
-RESOURCES_CONFIG = None
+
+def update_config(old_config, new_config, section, resource=None):
+    if section != SECTION_GLOBAL:
+        return
+    old_value = old_config.roles_to_assume
+    new_value = new_config.roles_to_assume
+    if new_value != old_value:
+        get_resources(reload=True)
+
+
+config.CONFIG_LISTENERS.add(update_config)
 
 
 def update_resources(section=None):
-    RESOURCES_CONFIG.kinesis = themis.monitoring.kinesis_monitoring.update_resources(RESOURCES_CONFIG.kinesis)
-    RESOURCES_CONFIG.emr = themis.monitoring.emr_monitoring.update_resources(RESOURCES_CONFIG.emr)
-    common.save_file(RESOURCES_FILE_LOCATION, RESOURCES_CONFIG.to_json())
+    cfg = load_resources_config()
+    cfg.kinesis = themis.monitoring.kinesis_monitoring.update_resources(cfg.kinesis)
+    cfg.emr = themis.monitoring.emr_monitoring.update_resources(cfg.emr)
+    save_resources_file(cfg)
 
 
-def get_resources(section=None):
-    global RESOURCES_CONFIG
+def get_resources(section=None, reload=False):
+    if reload and os.path.isfile(RESOURCES_FILE_LOCATION):
+        os.remove(RESOURCES_FILE_LOCATION)
+    reloaded = False
     if not os.path.isfile(RESOURCES_FILE_LOCATION):
         init_resources_file()
-        RESOURCES_CONFIG = None
-    if RESOURCES_CONFIG is None:
-        content = load_json_file(RESOURCES_FILE_LOCATION)
-        RESOURCES_CONFIG = ResourcesConfiguration.from_dict(content)
-    update_resources(section)
+        reloaded = True
+    config = load_resources_config()
+    if reloaded:
+        update_resources(section)
     if not section:
-        return RESOURCES_CONFIG.get_all()
-    return RESOURCES_CONFIG.get(section)
+        return config.get_all()
+    return config.get(section)
 
 
 def get_resource(section, resource_id):
@@ -39,23 +53,48 @@ def get_resource(section, resource_id):
     return None
 
 
+def load_resources_config():
+    content = load_json_file(RESOURCES_FILE_LOCATION)
+    cfg = ResourcesConfiguration.from_dict(content)
+    return cfg
+
+
+def save_resources_file(config):
+    common.save_file(RESOURCES_FILE_LOCATION, config.to_json())
+
+
 def save_resource(section, resource):
-    resources = get_resources(section)
+    config = load_resources_config()
+    resources = config.get(section)
     for i in range(0, len(resources)):
         if resources[i].id == resource.id:
             resources[i] = resource
-    common.save_file(RESOURCES_FILE_LOCATION, RESOURCES_CONFIG.to_json())
+    save_resources_file(config)
 
 
 def init_resources_file(run_parallel=False):
     if os.path.isfile(RESOURCES_FILE_LOCATION):
         return
 
+    sys_config = get_config()
+    roles = re.split(r'\s*,\s*', sys_config.general.roles_to_assume)
+
     cfg = ResourcesConfiguration()
     LOG.info("Initializing config file with list of resources from AWS: %s" % RESOURCES_FILE_LOCATION)
-    # load resources
-    cfg.kinesis = themis.monitoring.kinesis_monitoring.init_kinesis_config(run_parallel=run_parallel).kinesis
-    cfg.emr = themis.monitoring.emr_monitoring.init_emr_config(run_parallel=run_parallel).emr
+
+    for role in roles:
+        # load resources
+        kinesis_streams = themis.monitoring.kinesis_monitoring.init_kinesis_config(
+            run_parallel=run_parallel, role=role).kinesis
+        emr_clusters = themis.monitoring.emr_monitoring.init_emr_config(
+            run_parallel=run_parallel, role=role).emr
+        for stream in kinesis_streams:
+            cfg.kinesis.append(stream)
+            config.set_value('role_to_assume', role, section=SECTION_KINESIS, resource=stream.id)
+        for cluster in emr_clusters:
+            cfg.emr.append(cluster)
+            config.set_value('role_to_assume', role, section=SECTION_EMR, resource=cluster.id)
+
     # save config file
-    common.save_file(RESOURCES_FILE_LOCATION, cfg.to_json())
+    save_resources_file(cfg)
     LOG.info('Done initializing.')

--- a/themis/scaling/kinesis_scaling.py
+++ b/themis/scaling/kinesis_scaling.py
@@ -91,7 +91,8 @@ def perform_scaling(kinesis_stream):
     downscale = get_downscale_shards(kinesis_stream)
     upscale = get_upscale_shards(kinesis_stream)
     action = 'NOTHING'
-    kinesis_client = aws_common.connect_kinesis()
+    role = kinesis_monitoring.get_iam_role_for_stream(kinesis_stream)
+    kinesis_client = aws_common.connect_kinesis(role=role)
     try:
         if downscale:
             action = 'DOWNSCALE(-%s)' % len(downscale)

--- a/themis/scaling/kinesis_scaling.py
+++ b/themis/scaling/kinesis_scaling.py
@@ -79,7 +79,7 @@ def get_largest_shard(stream):
 
 
 def add_history_entry(stream, state, action):
-    database.history_add(section=SECTION_KINESIS, resource=stream.id, state=state, action=action)
+    return database.history_add(section=SECTION_KINESIS, resource=stream.id, state=state, action=action)
 
 
 def save_modified_stream(stream):
@@ -113,7 +113,8 @@ def perform_scaling(kinesis_stream):
     if downscale or upscale:
         save_modified_stream(kinesis_stream)
     state = kinesis_stream.monitoring_data
-    add_history_entry(kinesis_stream, state=state, action=action)
+    entry = add_history_entry(kinesis_stream, state=state, action=action)
+    return entry
 
 
 def execute_dsl_string(dsl_str, context, config=None):

--- a/themis/util/aws_common.py
+++ b/themis/util/aws_common.py
@@ -3,11 +3,13 @@ import json
 import logging
 import boto3
 import os
+from datetime import datetime
 from themis import config, constants
 from themis.config import SECTION_EMR
-from themis.util.common import run_func, remove_lines_from_string, get_logger
+from themis.util.common import run_func, remove_lines_from_string, get_logger, short_uid, is_ip_address
 from themis.util.common import CURL_CONNECT_TIMEOUT, STATIC_INFO_CACHE_TIMEOUT, QUERY_CACHE_TIMEOUT
 from themis.util.remote import run_ssh
+
 # constants
 
 PRESTO_STATE_SHUTTING_DOWN = 'SHUTTING_DOWN'
@@ -29,8 +31,46 @@ CLUSTER_TYPE_HIVE = 'Hive'
 # Define local test endpoints
 TEST_ENDPOINTS = {}
 
+# Keep a reference to the initial boto3 session with default credentials
+INITIAL_BOTO3_SESSION = None
+
+# Map role ARNs to sessions with assumed roles
+ASSUMED_ROLE_SESSIONS = {}
+
+# Timespan before expiry to renew session
+SESSION_EXPIRY_RENEW_PERIOD = 10 * 60
+
 # logger
 LOG = get_logger(__name__)
+
+
+class StsSession(object):
+    def __init__(self, role_arn):
+        self.session = None
+        self.role_arn = role_arn
+
+    def get(self):
+        if not self.role_arn:
+            # work with default boto3 session
+            return boto3
+        if not self.session or self.expires_soon():
+            # create a new boto3 session using assume-role
+            self.session = do_assume_role(self.role_arn)
+        return self.session
+
+    def expires_soon(self):
+        return session_expires_soon(self.session)
+
+
+def session_expires_soon(session):
+    exp = session.expiration
+    now = datetime.now()
+    # make dates substractable
+    exp = exp.replace(tzinfo=None)
+    now = now.replace(tzinfo=None)
+    # get delta
+    delta = (exp - now).total_seconds()
+    return delta < SESSION_EXPIRY_RENEW_PERIOD
 
 
 def init_aws_cli():
@@ -42,25 +82,54 @@ def init_aws_cli():
         TEST_ENDPOINTS['ec2'] = endpoint_url
 
 
-def connect_emr():
-    return connect_to_service('emr')
+def connect_emr(session=None, role=None):
+    return connect_to_service('emr', session=session, role=role)
 
 
-def connect_kinesis():
-    return connect_to_service('kinesis')
+def connect_kinesis(session=None, role=None):
+    return connect_to_service('kinesis', session=session, role=role)
 
 
-def connect_cloudwatch():
-    return connect_to_service('cloudwatch')
+def connect_cloudwatch(session=None, role=None):
+    return connect_to_service('cloudwatch', session=session, role=role)
 
 
-def connect_ec2():
-    return connect_to_service('ec2')
+def connect_ec2(session=None, role=None):
+    return connect_to_service('ec2', session=session, role=role)
 
 
-def connect_to_service(service):
+def connect_to_service(service, session=None, role=None):
+    session = session if session else assume_role(role) if role else None
     endpoint_url = TEST_ENDPOINTS.get(service)
-    return boto3.client(service, endpoint_url=endpoint_url)
+    boto3_session = session.get() if session else boto3
+    return boto3_session.client(service, endpoint_url=endpoint_url)
+
+
+def assume_role(role_arn):
+    return StsSession(role_arn)
+
+
+def do_assume_role(role_arn):
+    session = ASSUMED_ROLE_SESSIONS.get(role_arn)
+    if not session or session_expires_soon(session):
+        global INITIAL_BOTO3_SESSION
+        # save initial session with micros credentials to use for assuming role
+        if not INITIAL_BOTO3_SESSION:
+            INITIAL_BOTO3_SESSION = boto3.session.Session()
+        client = INITIAL_BOTO3_SESSION.client('sts')
+        # generate a random role session name
+        role_session_name = 's-' + str(short_uid())
+        # make API call to assume role
+        response = client.assume_role(RoleArn=role_arn, RoleSessionName=role_session_name)
+        # save session with new credentials to use for all aws calls
+        session = boto3.session.Session(
+            aws_access_key_id=response['Credentials']['AccessKeyId'],
+            aws_secret_access_key=response['Credentials']['SecretAccessKey'],
+            aws_session_token=response['Credentials']['SessionToken'])
+        session.expiration = response['Credentials']['Expiration']
+        # store session for future reference
+        ASSUMED_ROLE_SESSIONS[role_arn] = session
+    return session
 
 
 def ip_to_hostname(ip, domain_name):
@@ -71,8 +140,8 @@ def hostname_to_ip(host):
     return re.sub(r'ip-([0-9]+)-([0-9]+)-([0-9]+)-([0-9]+)\..+', r'\1.\2.\3.\4', host)
 
 
-def get_instance_by_ip(ip):
-    ec2_client = connect_ec2()
+def get_instance_by_ip(ip, role=None):
+    ec2_client = connect_ec2(role=role)
     result = run_func(ec2_client.describe_instances,
         Filters=[{'Name': 'private-ip-address', 'Values': [ip]}],
         cache_duration_secs=STATIC_INFO_CACHE_TIMEOUT)
@@ -80,8 +149,8 @@ def get_instance_by_ip(ip):
     return result['Reservations'][0]['Instances'][0]
 
 
-def get_instance_groups(cluster_id):
-    emr_client = connect_emr()
+def get_instance_groups(cluster_id, role=None):
+    emr_client = connect_emr(role=role)
     result = run_func(emr_client.list_instance_groups, ClusterId=cluster_id,
         cache_duration_secs=QUERY_CACHE_TIMEOUT)
     result = json.loads(result)
@@ -97,21 +166,21 @@ def get_instance_groups(cluster_id):
     return result_map
 
 
-def get_instance_groups_tasknodes(cluster_id):
-    return get_instance_groups(cluster_id)[INSTANCE_GROUP_TYPE_TASK]
+def get_instance_groups_tasknodes(cluster_id, role=None):
+    return get_instance_groups(cluster_id, role=role)[INSTANCE_GROUP_TYPE_TASK]
 
 
-def get_instance_groups_ids(cluster_id, group_type):
-    groups = get_instance_groups(cluster_id)
+def get_instance_groups_ids(cluster_id, group_type, role=None):
+    groups = get_instance_groups(cluster_id, role=role)
     return groups[group_type]
 
 
-def get_instance_group_type(cluster_id, group_id):
-    return get_instance_group_details(cluster_id, group_id)['type']
+def get_instance_group_type(cluster_id, group_id, role=None):
+    return get_instance_group_details(cluster_id, group_id, role=role)['type']
 
 
-def get_instance_group_details(cluster_id, group_id):
-    groups = get_instance_groups(cluster_id)
+def get_instance_group_details(cluster_id, group_id, role=None):
+    groups = get_instance_groups(cluster_id, role=role)
     for key, arr in groups.iteritems():
         for val in arr:
             if val['id'] == group_id:
@@ -119,16 +188,16 @@ def get_instance_group_details(cluster_id, group_id):
     return None
 
 
-def get_instance_group_for_node(cluster_id, node_host):
-    nodes = get_cluster_nodes(cluster_id)
+def get_instance_group_for_node(cluster_id, node_host, role=None):
+    nodes = get_cluster_nodes(cluster_id, role=role)
     for node in nodes:
         if node['host'] == node_host or node['ip'] == node_host:
             return node['gid']
     return None
 
 
-def get_cluster_nodes(cluster_id):
-    emr_client = connect_emr()
+def get_cluster_nodes(cluster_id, role=None):
+    emr_client = connect_emr(role=role)
     result = run_func(emr_client.list_instances, ClusterId=cluster_id,
         InstanceStates=['AWAITING_FULFILLMENT', 'PROVISIONING', 'BOOTSTRAPPING', 'RUNNING'],
         cache_duration_secs=QUERY_CACHE_TIMEOUT)
@@ -152,22 +221,22 @@ def get_cluster_nodes(cluster_id):
             inst['host'] = inst['PrivateDnsName'] if 'PrivateDnsName' in inst else 'n/a'
             if custom_dn:
                 inst['host'] = ip_to_hostname(hostname_to_ip(inst['host']), custom_dn)
-            inst['type'] = get_instance_group_type(cluster_id, inst['InstanceGroupId'])
+            inst['type'] = get_instance_group_type(cluster_id, inst['InstanceGroupId'], role=role)
             inst['state'] = inst['Status']['State']
-            inst['market'] = get_instance_group_details(cluster_id, inst['InstanceGroupId'])['Market']
+            inst['market'] = get_instance_group_details(cluster_id, inst['InstanceGroupId'], role=role)['Market']
         i += 1
     return result
 
 
-def get_all_task_nodes(cluster_id, cluster_ip):
-    all_nodes = get_cluster_nodes(cluster_id)
+def get_all_task_nodes(cluster_id, cluster_ip, role=None):
+    all_nodes = get_cluster_nodes(cluster_id, role=role)
     task_nodes = [n for n in all_nodes if n['type'] == INSTANCE_GROUP_TYPE_TASK]
     return task_nodes
 
 
-def terminate_task_node(instance_group_id, instance_id):
+def terminate_task_node(instance_group_id, instance_id, role=None):
     # terminate instance
-    emr_client = connect_emr()
+    emr_client = connect_emr(role=role)
     LOG.info('Terminate instance %s of instance group %s' % (instance_id, instance_group_id))
     result = emr_client.modify_instance_groups(InstanceGroups=[
         {'InstanceGroupId': instance_group_id, 'EC2InstanceIdsToTerminate': [instance_id]}
@@ -175,9 +244,9 @@ def terminate_task_node(instance_group_id, instance_id):
     return result
 
 
-def spawn_task_node(instance_group_id, current_size, additional_nodes=1):
+def spawn_task_node(instance_group_id, current_size, additional_nodes=1, role=None):
     # start new instance
-    emr_client = connect_emr()
+    emr_client = connect_emr(role=role)
     new_size = current_size + additional_nodes
     LOG.info('Increase instances of instance group %s from %s to %s' %
         (instance_group_id, current_size, new_size))
@@ -191,7 +260,7 @@ def is_presto_cluster(cluster):
     return cluster.type == 'Presto'
 
 
-def terminate_inactive_nodes(cluster, cluster_state):
+def terminate_inactive_nodes(cluster, cluster_state, role=None):
     if not is_presto_cluster(cluster):
         return
     nodes = cluster_state['nodes']
@@ -205,7 +274,7 @@ def terminate_inactive_nodes(cluster, cluster_state):
                 if INVALID_CONFIG_VALUE in out:
                     LOG.info("Terminating instance of idle node %s in instance group %s" %
                         (node['iid'], node['gid']))
-                    terminate_task_node(instance_group_id=node['gid'], instance_id=node['iid'])
+                    terminate_task_node(instance_group_id=node['gid'], instance_id=node['iid'], role=role)
             except Exception, e:
                 LOG.info("Unable to read Presto config from node %s: %s" % (node, e))
 
@@ -221,6 +290,8 @@ def get_presto_node_state(cluster_ip, node_ip):
 def set_presto_node_state(cluster_ip, node_ip, state):
     cmd = ("sudo sed -i 's/http-server.threads.max=.*/http-server.threads.max=%s/g' " +
         "/etc/presto/conf/config.properties") % INVALID_CONFIG_VALUE
+    if not is_ip_address(cluster_ip):
+        cluster_ip = hostname_to_ip(cluster_ip)
     out = run_ssh(cmd, cluster_ip, user='hadoop', via_hosts=[node_ip], cache_duration_secs=QUERY_CACHE_TIMEOUT)
 
     cmd = ("curl -s --connect-timeout %s -X PUT -H 'Content-Type:application/json' " +

--- a/themis/util/common.py
+++ b/themis/util/common.py
@@ -138,6 +138,10 @@ def is_number(s):
         return False
 
 
+def is_ip_address(s):
+    return re.match(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$', s)
+
+
 def is_NaN(obj, expect_only_numbers=False):
     if expect_only_numbers and not is_number(obj):
         return True

--- a/themis/util/common.py
+++ b/themis/util/common.py
@@ -28,8 +28,8 @@ STATIC_INFO_CACHE_TIMEOUT = 60 * 30
 
 # cache globals
 last_cache_clean_time = 0
-mutex_clean = threading.Semaphore(1)
-mutex_popen = threading.Semaphore(1)
+mutex_clean = threading.RLock()
+mutex_popen = threading.RLock()
 
 
 def get_logger(name=None):
@@ -38,6 +38,27 @@ def get_logger(name=None):
 
 # logger
 LOG = get_logger(__name__)
+
+
+class FuncThread(threading.Thread):
+    def __init__(self, func, params, quiet=False):
+        threading.Thread.__init__(self)
+        self.daemon = True
+        self.params = params
+        self.func = func
+        self.quiet = quiet
+
+    def run(self):
+        try:
+            self.func(self.params)
+        except Exception, e:
+            if not self.quiet:
+                print("Thread run method %s(%s) failed: %s" %
+                    (self.func, self.params, traceback.format_exc()))
+
+    def stop(self, quiet=False):
+        if not quiet and not self.quiet:
+            print("WARN: not implemented: FuncThread.stop(..)")
 
 
 def clean_cache():

--- a/themis/util/expr.py
+++ b/themis/util/expr.py
@@ -34,16 +34,13 @@ class NodesInfo:
 
 class CountStatsExpr:
     def __init__(self, info):
-        if 'nodes' in info:
-            self.nodes = info['nodes']
+        self.nodes = info.get('nodes')
 
 
 class AggregateStatsExpr:
     def __init__(self, info):
-        if 'cpu' in info:
-            self.cpu = info['cpu']
-        if 'mem' in info:
-            self.mem = info['mem']
+        self.cpu = info.get('cpu')
+        self.mem = info.get('mem')
 
 
 class TimeBasedScaling:
@@ -54,7 +51,7 @@ class TimeBasedScaling:
 
 class TimeBasedMinimumNodes:
     def __init__(self, info):
-        self.nodes = info['nodes'] if 'nodes' in info else []
+        self.nodes = info.get('nodes', [])
 
 
 class ExprContext:

--- a/themis/util/remote.py
+++ b/themis/util/remote.py
@@ -1,13 +1,45 @@
+import subprocess
+import re
+import os
 from themis.util import common
-from themis.util.common import run
+from themis.util.common import run, save_file, get_logger
 from themis import config
 from themis.constants import *
-import subprocess
+
+KEY_FILE_NAME_PATTERN = '/tmp/ssh.key.%s.pem'
+
+# logger
+LOG = get_logger(__name__)
+
+
+def get_ssh_keys():
+    keys = re.split(r'\s*,\s*', config.get_value(KEY_SSH_KEYS))
+    for i in range(0, len(keys)):
+        key = keys[i]
+        if key[0] == '$':
+            var_name = key[1:]
+            key_file = KEY_FILE_NAME_PATTERN % var_name
+            if not os.path.isfile(key_file):
+                key_value = os.environ.get(var_name)
+                if key_value:
+                    key_value = key_value.replace(' ', '\n')
+                    marker_begin = '-----BEGIN RSA PRIVATE KEY-----'
+                    marker_end = '-----END RSA PRIVATE KEY-----'
+                    if marker_begin not in key_value:
+                        key_value = ('%s\n' % marker_begin) + key_value
+                    if marker_end not in key_value:
+                        key_value += ('\n%s' % marker_end)
+                    save_file(key_file, key_value)
+                    run('chmod 600 %s' % key_file)
+                else:
+                    LOG.warning('Unable to read SSH key from environment variable: %s' % var_name)
+            keys[i] = key_file
+    return keys
 
 
 def run_ssh(cmd, host, user=None, keys=None, via_hosts=[], cache_duration_secs=0):
     if not keys:
-        keys = config.get_value(KEY_SSH_KEYS).split(',')
+        keys = get_ssh_keys()
 
     user = '%s@' % user if user else ''
 

--- a/themis/web/js/app.js
+++ b/themis/web/js/app.js
@@ -215,7 +215,7 @@
 
   app.factory('restClient', function($resource) {
     return new SwaggerClient({
-      url: "//" + document.location.host + "/swagger.json",
+      url: document.location.protocol + "//" + document.location.host + "/swagger.json",
       usePromise: true
     });
   });

--- a/themis/web/views/config.html
+++ b/themis/web/views/config.html
@@ -30,7 +30,7 @@
             </tbody>
           </table>
           <div style="margin-top: 20px">
-            <button class="aui-button aui-button-primary" ng-click="save()">Save</button>
+            <button class="aui-button aui-button-primary" ng-disabled="saving" ng-click="save()">{{saving ? 'Saving...' : 'Save'}}</button>
           </div>
         </form>
       </div>

--- a/themis/web/views/config.js
+++ b/themis/web/views/config.js
@@ -7,6 +7,7 @@
 
     var client = restClient;
     appConfig.section = 'general';
+    $scope.saving = false;
 
     $scope.load = function() {
       $scope.loading = true;
@@ -24,12 +25,15 @@
 
     $scope.save = function() {
       /* load config */
+      $scope.saving = true;
       appConfig.setConfig($scope.config)
       .then(function(config) {
         $scope.$apply(function(){
+          $scope.saving = false;
           $scope.config = config;
         });
       }, function(err) {
+        $scope.saving = false;
         console.log(err);
       });
     };


### PR DESCRIPTION
This PR adds support for temporary STS tokens via assumed IAM roles. This allows Themis to operate in cross-account environments.
* Add global configuration option `roles_to_assume`: comma-separated list of role ARNs
* Refactor code around initialization of themis.resources.json file. If configuration value `roles_to_assume` changes, re-initialize the resources file.
* Add a new class `StsSession` in `aws_common.py` that maintains (and automatically refreshes) temporary session tokens.
* Extend functions for monitoring/scaling to accept a `role` parameter, in order to use the respective roles/sessions when modifying resources