### PR TITLE
Add system load to EMR monitoring metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ make server
 
 ## Change Log
 
+* v0.2.9: Add system load to monitoring metrics for EMR clusters
 * v0.2.8: Fix shard-level metrics for Kinesis, add min/max/avg to UI
 * v0.2.7: Extended monitoring metrics for Kinesis
 * v0.2.6: Fix merging of adjacent Kinesis shards. Fix duplicates in EMR downscale candidates

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ if __name__ == '__main__':
 
     setup(
         name='themis-autoscaler',
-        version='0.2.8',
-        description='Themis is an autoscaler for Elastic Map Reduce (EMR) clusters on Amazon Web Services.',
+        version='0.2.9',
+        description='Autoscaling Elastic Map Reduce (EMR) clusters and Kinesis streams on Amazon Web Services.',
         author='Atlassian and others',
         maintainer='Waldemar Hummer',
         author_email='waldemar.hummer@gmail.com',

--- a/themis/config.py
+++ b/themis/config.py
@@ -150,6 +150,8 @@ class EmrConfiguration(ConfigObject):
 class EmrClusterConfiguration(ConfigObject):
     CONFIG_ITEMS = {
         'role_to_assume': 'ARN of IAM role to assume via STS when accessing this resource',
+        'send_shutdown_signal': ('Whether to send Presto SHUTDOWN signal before terminating a node ' +
+            '("true" or "false"). This has worked well up to EMR 4.x but does not seem to work in EMR 5+.'),
         'downscale_expr': 'Trigger cluster downscaling by the number of nodes this expression evaluates to',
         'upscale_expr': 'Trigger cluster upscaling by the number of nodes this expression evaluates to',
         'time_based_scaling': """A JSON string that maps date regular expressions to minimum number of nodes. \
@@ -177,6 +179,7 @@ class EmrClusterConfiguration(ConfigObject):
             'else "%s"') % (MARKET_ON_DEMAND, MARKET_SPOT)
         self.baseline_nodes = '20'
         self.custom_domain_name = ''
+        self.send_shutdown_signal = 'true'
 
 
 class KinesisConfiguration(ConfigObject):

--- a/themis/constants.py
+++ b/themis/constants.py
@@ -10,6 +10,7 @@ KEY_TIME_BASED_SCALING = 'time_based_scaling'
 KEY_BASELINE_COMPARISON_NODES = 'baseline_nodes'
 KEY_NOW = 'now'
 KEY_CUSTOM_DOMAIN_NAME = 'custom_domain_name'
+KEY_SEND_SHUTDOWN_SIGNAL = 'send_shutdown_signal'
 
 # default time to sleep between loops
 LOOP_SLEEP_TIMEOUT_SECS = 3 * 60

--- a/themis/web/views/emr.details.html
+++ b/themis/web/views/emr.details.html
@@ -51,6 +51,7 @@
                   <th ts-criteria="state_presto" id="node_state_presto" ng-show="state.data.is_presto">State (Presto)</th>
                   <th ts-criteria="load.cpu" id="load_cpu" ts-default>CPU Usage</th>
                   <th ts-criteria="load.mem" id="load_mem">Memory Usage</th>
+                  <th ts-criteria="load.sysload" id="load_sysload">System Load</th>
                   <th ts-criteria="queries" id="queries">Queries</th>
                   <th ts-criteria="actions" id="actions">Actions</th>
                 </tr>
@@ -65,6 +66,7 @@
                   <td headers="state_presto" ng-show="state.data.is_presto">{{value.presto_state}}</td>
                   <td headers="load_cpu">{{value.load.cpu | percentage}}</td>
                   <td headers="load_mem">{{value.load.mem | percentage}}</td>
+                  <td headers="load_sysload">{{value.load.sysload | number:2}}</td>
                   <td headers="queries">{{value.queries}}</td>
                   <td headers="actions"><button class="aui-button" ng-click="restartNode(value)" ng-disabled="refreshing[value.host]" ng-show="value.type == 'TASK'">Restart</button></td>
                 </tr>
@@ -77,6 +79,7 @@
                   <td ng-hide="!state.data.is_presto"></td>
                   <td headers="load_cpu">Ø {{state.data.tasknodes.average.cpu | percentage}}</td>
                   <td headers="load_mem">Ø {{state.data.tasknodes.average.mem | percentage}}</td>
+                  <td headers="load_mem">Ø {{state.data.tasknodes.average.sysload | number:2}}</td>
                   <td headers="queries">{{state.data.allnodes.sum.queries}}</td>
                   <td></td>
                 </tr>
@@ -103,6 +106,7 @@
                   <th ts-criteria="state.tasknodes.count.nodes" id="hist_nodes">Number of Nodes</th>
                   <th ts-criteria="state.tasknodes.average.cpu" id="hist_cpu">Ø Task Node CPU</th>
                   <th ts-criteria="state.tasknodes.average.mem" id="hist_mem">Ø Task Node Memory</th>
+                  <th ts-criteria="state.tasknodes.average.sysload" id="hist_sysload">Ø System Load</th>
                   <th ts-criteria="state.allnodes.sum.queries" id="hist_queries">Total Queries</th>
                   <th ts-criteria="action" id="hist_action">Action</th>
                 </tr>
@@ -113,6 +117,7 @@
                   <td headers="hist_nodes">{{value.state.tasknodes.count.nodes}}</td>
                   <td headers="hist_cpu">{{value.state.tasknodes.average.cpu | percentage}}</td>
                   <td headers="hist_mem">{{value.state.tasknodes.average.mem | percentage}}</td>
+                  <td headers="hist_sysload">{{value.state.tasknodes.average.sysload | number:2}}</td>
                   <td headers="hist_queries">{{value.state.allnodes.sum.queries}}</td>
                   <td headers="hist_action">{{value.action}}</td>
                 </tr>


### PR DESCRIPTION
This PR adds an additional "system load" metric for EMR nodes. Using the scaling DSL, the metric can be accessed via `node.load.sysload` (for a single node) or `tasknodes.average.sysload` (for all task nodes of a cluster).