### PR TITLE
Fix sysload in EMR DSL expressions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
 
     setup(
         name='themis-autoscaler',
-        version='0.2.9',
+        version='0.2.10',
         description='Autoscaling Elastic Map Reduce (EMR) clusters and Kinesis streams on Amazon Web Services.',
         author='Atlassian and others',
         maintainer='Waldemar Hummer',

--- a/themis/util/expr.py
+++ b/themis/util/expr.py
@@ -41,6 +41,7 @@ class AggregateStatsExpr:
     def __init__(self, info):
         self.cpu = info.get('cpu')
         self.mem = info.get('mem')
+        self.sysload = info.get('sysload')
 
 
 class TimeBasedScaling:


### PR DESCRIPTION
This PR contains a fix to include the `sysload` property in the EMR DSL expressions, where it's currently missing.